### PR TITLE
CHANGE(zookeeper): Ensure service is started or restarted at the end …

### DIFF
--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -23,13 +23,12 @@
   become: true
   vars:
     NS: TRAVIS
+    openio_bootstrap: true
   roles:
     - role: users
     - role: repo
       openio_repository_no_log: false
-      openio_repository_products:
-        sds:
-          release: "18.10"
+      openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
       openio_gridinit_per_ns: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,12 +60,32 @@
 
   register: _zookeeper_conf
 
-- name: restart zookeeper
+- name: "restart zookeeper to apply the new configuration"
   shell: |
     gridinit_cmd reload
     gridinit_cmd restart  {{ openio_zookeeper_namespace }}-{{ openio_zookeeper_servicename }}
+  register: _restart_zookeeper
   when:
-    - _zookeeper_conf.changed
+    - _zookeeper_conf is changed
     - not openio_zookeeper_provision_only
   tags: configure
+
+- block:
+    - name: "Ensure zookeeper is started"
+      command: gridinit_cmd start {{ openio_zookeeper_namespace }}-{{ openio_zookeeper_servicename }}
+      register: _start_zookeeper
+      changed_when: '"Success" in _start_zookeeper.stdout'
+      when:
+        - not openio_zookeeper_provision_only
+        - _restart_zookeeper is skipped
+      tags: configure
+
+    - name: check zookeeper
+      shell: "echo ruok | nc {{ openio_zookeeper_bind_address }} {{ openio_zookeeper_bind_port }}"
+      register: _zookeeper_check
+      retries: 3
+      delay: 5
+      until: _zookeeper_check.stdout.find("imok") != -1
+      changed_when: false
+  when: openio_bootstrap | d(false)
 ...

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -17,5 +17,6 @@ zookeeper_packages:
   - default-jre-headless
   - zookeeperd
   - python-zookeeper
+  - netcat
 syslog_user: syslog
 ...

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -9,6 +9,7 @@ zookeeper_packages:
   - java-headless
   - zookeeper
   - python-ZooKeeper
+  - nmap-ncat
 
 syslog_user: openio
 ...


### PR DESCRIPTION
…of role

 ##### SUMMARY
Until 18.10, a voluntarily stopped service was not revived by a reproviosionning.

In 19.04, the `maintenance` mode becomes the default mode.

To avoid having to force (ie. deletion of conf files) the restart of a service delivered first, by error, in maintenance mode: We have to make sure that service is started and it works well at the end of the role.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION