### PR TITLE
BUGFIX/MINOR(zookeeper): Fix healthcheck when check_mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -87,5 +87,6 @@
       delay: 5
       until: _zookeeper_check.stdout.find("imok") != -1
       changed_when: false
+      when: not ansible_check_mode
   when: openio_bootstrap | d(false)
 ...


### PR DESCRIPTION
 ##### SUMMARY
Skip the health_check in check mode

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION