### PR TITLE
CHANGE(zookeeper): Add flag to force package upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ An Ansible role for manage zookeeper. Specifically, the responsibilities of this
 | `openio_zookeeper_tick_time` | `2000` | The basic time unit in milliseconds used by ZooKeeper. It is used to do heartbeats and the minimum session timeout will be twice the tickTime |
 | `openio_zookeeper_volume` | `"/var/lib/oio/sds/{{ openio_zookeeper_namespace }}/zookeeper-{{ openio_zookeeper_serviceid }}"` | Path to store data |
 | `openio_zookeeper_provision_only` | `false` | Provision only without restarting services |
+| `openio_zookeeper_package_upgrade` | `false` | Set the packages to the latest version (to be set in extra_vars) |
 
 
 ## Dependencies

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,4 +49,6 @@ openio_zookeeper_gridinit_dir: "/etc/gridinit.d/{{ openio_zookeeper_namespace }}
 openio_zookeeper_gridinit_file_prefix: ""
 
 openio_zookeeper_provision_only: false
+
+openio_zookeeper_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 ...

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_zookeeper_package_upgrade else 'present' }}"
   with_items: "{{ zookeeper_packages }}"
   loop_control:
     loop_var: pkg

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -2,7 +2,7 @@
 - name: Install packages
   package:
     name: "{{ pkg }}"
-    state: present
+    state: "{{ 'latest' if openio_zookeeper_package_upgrade else 'present' }}"
   with_items: "{{ zookeeper_packages }}"
   loop_control:
     loop_var: pkg


### PR DESCRIPTION
 ##### SUMMARY

This is useful during upgrades, as it allows to update packages to the
latest version without requiring an external playbook/task.

To use this, simply provide the `-e openio_package_upgrade=true` argument

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION