### PR TITLE
CHANGE(zookeeper): Adapt config to zookeeper versions 3.5.x

### DIFF
--- a/templates/zookeeper.conf.j2
+++ b/templates/zookeeper.conf.j2
@@ -17,6 +17,8 @@ autopurge.snapRetainCount={{ openio_zookeeper_autopurge_snapRetainCount }}
 autopurge.purgeInterval={{ openio_zookeeper_autopurge_purgeInterval }}
 {% endif %}
 
+4lw.commands.whitelist=stat, ruok, conf, isro, srvr
+
 {% for server in openio_zookeeper_servers %}
 {% if server.host is defined %}
 {% if server.ip is defined %}


### PR DESCRIPTION
 ##### SUMMARY

The new zookeeper versions have blacklisted all 4 letters commands, so
re-enable them in the config file.

This is needed during the deployment to get the server's status with the
`ruok` command.

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### SCOPE (skeleton only)
- SDS

 ##### IMPACT
Unknown

 ##### ADDITIONAL INFORMATION
Additionnal informations here:
https://zookeeper.apache.org/doc/r3.5.5/zookeeperAdmin.html#sc_clusterOptions