### PR TITLE
CHANGE(zookeeper): Adapt classpath to zookeeper versions 3.5.x

### DIFF
--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -3,7 +3,7 @@
 ---
 openio_zookeeper_classpath:
   - "{{ openio_zookeeper_sysconfig_dir }}/{{ openio_zookeeper_servicename }}"
-  - /usr/share/zookeeper/*
+  - /usr/share/java/zookeeper/*
 
 zookeeper_packages:
   - java-headless


### PR DESCRIPTION
 ##### SUMMARY

The new zookeeper versions have changed where the jar files are placed.

 ##### ISSUE TYPE
- Bugfix Pull Request

 ##### SCOPE (skeleton only)
- SDS

 ##### IMPACT
Will not work with zookeeper 3.4.X packages

 ##### ADDITIONAL INFORMATION