### PR TITLE
BUGFIX/MINOR(zookeeper): Allow `mntr` for monitoring

### DIFF
--- a/templates/zookeeper.conf.j2
+++ b/templates/zookeeper.conf.j2
@@ -17,7 +17,7 @@ autopurge.snapRetainCount={{ openio_zookeeper_autopurge_snapRetainCount }}
 autopurge.purgeInterval={{ openio_zookeeper_autopurge_purgeInterval }}
 {% endif %}
 
-4lw.commands.whitelist=stat, ruok, conf, isro, srvr
+4lw.commands.whitelist=stat, ruok, conf, isro, srvr, mntr
 
 {% for server in openio_zookeeper_servers %}
 {% if server.host is defined %}


### PR DESCRIPTION
 ##### SUMMARY

Outputs a list of variables that could be used for monitoring the health of the cluster.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION