### PR TITLE
BUGFIX/MINOR(SDS): Drop package `python2-zookeeper`

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -16,7 +16,6 @@ openio_zookeeper_classpath:
 zookeeper_packages:
   - default-jre-headless
   - zookeeperd
-  - python-zookeeper
   - python3-zookeeper
   - netcat
 syslog_user: syslog

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,7 +8,6 @@ openio_zookeeper_classpath:
 zookeeper_packages:
   - java-headless
   - zookeeper
-  - python-zookeeper
   - python3-zookeeper
   - nmap-ncat
 


### PR DESCRIPTION
 ##### SUMMARY

This package is not required any more.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION