### PR TITLE
BUGFIX/MINOR(zookeeper): Fix wrong ownership on log directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,18 @@
 # .travis.yml Execution script for role tests on Travis-CI
 ---
-dist: xenial
+dist: bionic
 sudo: required
 
 env:
   global:
-    - ANSIBLE_VERSION=2.5
+    - ANSIBLE_VERSION=2.9
   matrix:
     - DISTRIBUTION: centos
       VERSION: 7
 #    - DISTRIBUTION: centos
 #      VERSION: 8
-    - DISTRIBUTION: ubuntu
-      VERSION: 16.04
+#    - DISTRIBUTION: ubuntu
+#      VERSION: 16.04
     - DISTRIBUTION: ubuntu
       VERSION: 18.04
 #    - DISTRIBUTION: debian
@@ -20,6 +20,10 @@ env:
 
 services:
   - docker
+
+language: python
+python:
+  - "3.6"
 
 before_install:
   # Install latest Git

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,7 @@
     - path: "{{ openio_zookeeper_volume }}"
     - path: "{{ openio_zookeeper_log_dir }}"
       owner: "{{ syslog_user }}"
-      mode: "0750"
+      mode: "{{ '0750' if ansible_os_family == 'RedHat' else '0770' }}"
   tags: configure
 
 - name: Generate configuration files


### PR DESCRIPTION
 ##### SUMMARY

Zookeeper manages its own logs without calls through syslog.
On Ubuntu (as on centos 7), the folder is created in 0750 syslog/openio (openio/openio)

Rsyslog runs as `syslog` on ubuntu

```console
root@bionic5:/# ls /var/log/oio/sds/OPENIO/zookeeper-0/ -ald
drwxr-x--- 2 syslog openio 6 Jan 20 16:45 /var/log/oio/sds/OPENIO/zookeeper-0/

root@bionic5:/# cat /etc/os-release
NAME="Ubuntu"
VERSION="18.04.2 LTS (Bionic Beaver)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 18.04.2 LTS"
VERSION_ID="18.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=bionic
UBUNTU_CODENAME=bionic
```

So it’s impossible for zookeeper which runs as an openio to write to this folder !

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
OS-482