### PR TITLE
CHANGE(zookeeper): Change default of `gridinit_dir`, `gridinit_file_p…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,10 +44,10 @@ openio_zookeeper_servers:
   - ip: "{{ openio_zookeeper_bind_address }}"
     id: 1
 #openio_zookeeper_hostname: "{{ ansible_hostname }}"
-openio_zookeeper_gridinit_dir: "/etc/gridinit.d/{{ openio_zookeeper_namespace }}"
-openio_zookeeper_gridinit_file_prefix: ""
+openio_zookeeper_gridinit_dir: "{{ openio_gridinit_d | d('/etc/gridinit.d/') }}"
+openio_zookeeper_gridinit_file_prefix: "{{ openio_zookeeper_namespace }}-"
 
-openio_zookeeper_provision_only: false
+openio_zookeeper_provision_only: "{{ openio_maintenance_mode | d(false) | bool }}"
 
 openio_zookeeper_package_upgrade: "{{ openio_package_upgrade | d(false) }}"
 

--- a/docker-tests/test.yml
+++ b/docker-tests/test.yml
@@ -31,7 +31,7 @@
       openio_repository_mirror_host: mirror2.openio.io
     - role: gridinit
       openio_gridinit_namespace: "{{ NS }}"
-      openio_gridinit_per_ns: true
+      #openio_gridinit_per_ns: true
 
     - role: role_under_test
       openio_zookeeper_namespace: "{{ NS }}"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,16 @@
 ---
 galaxy_info:
   author: Cedric DELGEHIER <cedric@openio.io>
-  description: PURPOSE
+  description: Install zookeeper for OpenIO
   company: OpenIO
-  license: Apache
+  license: AGPLv3
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.9
 
   platforms:
     - name: Ubuntu
       versions:
-        - xenial
+        - bionic
     - name: EL
       versions:
         - 7

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,7 +29,6 @@
     group: "{{ item.group | default('openio') }}"
     mode: "{{ item.mode | default(0755) }}"
   with_items:
-    - path: "/etc/gridinit.d/{{ openio_zookeeper_namespace }}"
     - path: "{{ openio_zookeeper_sysconfig_dir }}/{{ openio_zookeeper_servicename }}"
     - path: "{{ openio_zookeeper_volume }}"
     - path: "{{ openio_zookeeper_log_dir }}"


### PR DESCRIPTION
…refix` and `provision_only`

 ##### SUMMARY

The playbook hardcode these calls. Now the defaults are good and there is no more hardcode.

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION