### PR TITLE
FEATURE(zookeeper): Improve zookeeper log rotation

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,6 +39,8 @@ openio_zookeeper_autopurge_snapRetainCount: 3
 openio_zookeeper_autopurge_purgeInterval: 1
 openio_zookeeper_log_properties: "INFO,ROLLINGFILE"
 openio_zookeeper_rolling_log_file_max_size: "10MB"
+openio_zookeeper_rolling_log_file_max_index: ""
+
 
 openio_zookeeper_servers:
   - ip: "{{ openio_zookeeper_bind_address }}"

--- a/templates/log4j.properties.j2
+++ b/templates/log4j.properties.j2
@@ -33,7 +33,8 @@ log4j.appender.ROLLINGFILE.File={{ openio_zookeeper_log_dir }}/zookeeper.log
 # Max log file size of 10MB
 log4j.appender.ROLLINGFILE.MaxFileSize={{ openio_zookeeper_rolling_log_file_max_size }}
 # uncomment the next line to limit number of backup files
-#log4j.appender.ROLLINGFILE.MaxBackupIndex=10
+{{ '#log4j.appender.ROLLINGFILE.MaxBackupIndex=10' if not openio_zookeeper_rolling_log_file_max_index
+   else 'log4j.appender.ROLLINGFILE.MaxBackupIndex=' ~ (openio_zookeeper_rolling_log_file_max_index | int) }}
 
 log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n


### PR DESCRIPTION
 ##### SUMMARY

Currently, Zookeeper logs are limited in number to 2 files (current + 1 rotation), with a file size of 10MB max. When an issue occurs, these logs will be quickly flooded;

 ##### IMPACT
N/A

 ##### ADDITIONAL INFORMATION
```yaml
    - role: zookeeper
      openio_zookeeper_rolling_log_file_max_index: 12
```
```console
TASK [role_under_test : Generate configuration files] ******************************************************************************************************************************************************
Monday 11 May 2020  10:58:09 +0000 (0:00:00.471)       0:00:12.405 ************
ok: [localhost] => (item={u'dest': u'/etc/oio/sds/TRAVIS/zookeeper-0/zoo.cfg', u'src': u'zookeeper.conf.j2'})
--- before: /etc/oio/sds/TRAVIS/zookeeper-0/log4j.properties
+++ after: /root/.ansible/tmp/ansible-local-31108fcwZE/tmpWECOnC/log4j.properties.j2
@@ -33,7 +33,7 @@
 # Max log file size of 10MB
 log4j.appender.ROLLINGFILE.MaxFileSize=10MB
 # uncomment the next line to limit number of backup files
-#log4j.appender.ROLLINGFILE.MaxBackupIndex=10
+log4j.appender.ROLLINGFILE.MaxBackupIndex=12

 log4j.appender.ROLLINGFILE.layout=org.apache.log4j.PatternLayout
 log4j.appender.ROLLINGFILE.layout.ConversionPattern=%d{ISO8601} - %-5p [%t:%C{1}@%L] - %m%n

changed: [localhost] => (item={u'dest': u'/etc/oio/sds/TRAVIS/zookeeper-0/log4j.properties', u'src': u'log4j.properties.j2'})
ok: [localhost] => (item={u'dest': u'/etc/oio/sds/TRAVIS/zookeeper-0/java.env', u'src': u'java.env.j2'})
ok: [localhost] => (item={u'dest': u'/etc/gridinit.d//TRAVIS-zookeeper-0.conf', u'src': u'gridinit_zookeeper.conf.j2'})
ok: [localhost] => (item={u'dest': u'/var/lib/oio/sds/TRAVIS/zookeeper-0/myid', u'src': u'myid.j2'})

TASK [role_under_test : restart zookeeper to apply the new configuration] **********************************************************************************************************************************
Monday 11 May 2020  10:58:11 +0000 (0:00:01.845)       0:00:14.250 ************
changed: [localhost]
```